### PR TITLE
Add WidgetIntents.strings to mandatory keys for import

### DIFF
--- a/Sources/LocalizationTools/main.swift
+++ b/Sources/LocalizationTools/main.swift
@@ -8,24 +8,24 @@ import ArgumentParser
 struct LocalizationTools: ParsableCommand {
     @Option(help: "Path to the project")
     var projectPath: String
-    
+
     @Option(name: .customLong("l10n-project-path"), help: "Path to the l10n project")
     var l10nProjectPath: String
-	
+
     @Option(name: .customLong("locale"), help: "Locale code for single locale import/export")
-    var localeCode: String?	
-    
+    var localeCode: String?
+
     @Flag(name: .customLong("export"), help: "To determine if we should run the export task.")
     var runExportTask = false
-    
+
     @Flag(name: .customLong("import"), help: "To determine if we should run the import task.")
     var runImportTask = false
-    
+
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "l10nTools", abstract: "Scripts for automating l10n for Mozilla iOS projects.", discussion: "", version: "1.0", shouldDisplay: true, subcommands: [], defaultSubcommand: nil, helpNames: .long)
-        
+
     }
-    
+
     private func validateArguments() -> Bool {
         switch (runExportTask, runImportTask) {
         case (false, false):
@@ -37,10 +37,10 @@ struct LocalizationTools: ParsableCommand {
         default: return true;
         }
     }
-    
+
     mutating func run() throws {
         guard validateArguments() else { Self.exit() }
-        
+
         var locales: [String]
 
         if localeCode != nil {
@@ -55,11 +55,11 @@ struct LocalizationTools: ParsableCommand {
             locales = locales.filter{ $0 != "templates" }
             locales.sort()
         }
-            
+
         if runImportTask {
             ImportTask(xcodeProjPath: projectPath, l10nRepoPath: l10nProjectPath, locales: locales).run()
         }
-        
+
         if runExportTask {
             ExportTask(xcodeProjPath: projectPath, l10nRepoPath: l10nProjectPath, locales: locales).run()
 			/// Don't extract templates if only one locale was requested

--- a/Sources/LocalizationTools/tasks/CreateTemplatesTask.swift
+++ b/Sources/LocalizationTools/tasks/CreateTemplatesTask.swift
@@ -6,7 +6,7 @@ import Foundation
 
 struct CreateTemplatesTask {
     let l10nRepoPath: String
-    
+
     private func copyEnLocaleToTemplates() {
         let source = URL(fileURLWithPath: "\(l10nRepoPath)/en-US/firefox-ios.xliff")
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("temp.xliff")
@@ -14,22 +14,22 @@ struct CreateTemplatesTask {
         try! FileManager.default.copyItem(at: source, to: tmp)
         _ = try! FileManager.default.replaceItemAt(destination, withItemAt: tmp)
     }
-    
+
     private func handleXML() throws {
         let url = URL(fileURLWithPath: "\(l10nRepoPath)/templates/firefox-ios.xliff")
         let xml = try! XMLDocument(contentsOf: url, options: .nodePreserveWhitespace)
-        
+
         guard let root = xml.rootElement() else { return }
-    
+
         try root.nodes(forXPath: "file").forEach { node in
             guard let node = node as? XMLElement else { return }
             node.removeAttribute(forName: "target-language")
         }
-        
+
         try root.nodes(forXPath: "file/body/trans-unit/target").forEach { $0.detach() }
         try xml.xmlString.write(to: url, atomically: true, encoding: .utf8)
     }
-    
+
     func run() {
         copyEnLocaleToTemplates()
         try! handleXML()

--- a/Sources/LocalizationTools/tasks/ExportTask.swift
+++ b/Sources/LocalizationTools/tasks/ExportTask.swift
@@ -13,15 +13,6 @@ struct ExportTask {
     private let group = DispatchGroup()
 
     private let EXCLUDED_TRANSLATIONS: Set<String> = ["CFBundleName", "CFBundleDisplayName", "CFBundleShortVersionString", "1Password Fill Browser Action"]
-    private let REQUIRED_TRANSLATIONS: Set<String> = [
-        "NSCameraUsageDescription",
-        "NSLocationWhenInUseUsageDescription",
-        "NSMicrophoneUsageDescription",
-        "NSPhotoLibraryAddUsageDescription",
-        "ShortcutItemTitleNewPrivateTab",
-        "ShortcutItemTitleNewTab",
-        "ShortcutItemTitleQRCode",
-    ]
 
     /// This dictionary holds locale mappings between `[PontoonLocaleCode: XCodeLocaleCode]`.
     private let LOCALE_MAPPING = [

--- a/Sources/LocalizationTools/tasks/ExportTask.swift
+++ b/Sources/LocalizationTools/tasks/ExportTask.swift
@@ -8,7 +8,7 @@ struct ExportTask {
     let xcodeProjPath: String
     let l10nRepoPath: String
     let locales: [String]
-    
+
     private let queue = DispatchQueue(label: "backgroundQueue", attributes: .concurrent)
     private let group = DispatchGroup()
 
@@ -22,7 +22,7 @@ struct ExportTask {
         "ShortcutItemTitleNewTab",
         "ShortcutItemTitleQRCode",
     ]
-    
+
     /// This dictionary holds locale mappings between `[PontoonLocaleCode: XCodeLocaleCode]`.
     private let LOCALE_MAPPING = [
         "ga" : "ga-IE",
@@ -32,10 +32,10 @@ struct ExportTask {
         "fil" : "tl",
         "sat-Olck" : "sat",
     ]
-    
+
     private let EXPORT_BASE_PATH = "/tmp/ios-localization"
-    
-    
+
+
     private func exportLocales() {
         let command = "xcodebuild -exportLocalizations -project \(xcodeProjPath) -localizationPath \(EXPORT_BASE_PATH)"
         let command2 = locales
@@ -47,7 +47,7 @@ struct ExportTask {
         try! task.run()
         task.waitUntilExit()
     }
-    
+
     private func handleXML(path: String, locale: String, commentOverrides: [String : String]) {
         let url = URL(fileURLWithPath: path.appending("/\(locale).xcloc/Localized Contents/\(locale).xliff"))
         let xml = try! XMLDocument(contentsOf: url, options: [.nodePreserveWhitespace, .nodeCompactEmptyElement])
@@ -57,22 +57,22 @@ struct ExportTask {
             if let xcodeLocale = LOCALE_MAPPING[locale] {
                 fileNode.attribute(forName: "target-language")?.setStringValue(xcodeLocale, resolvingEntities: false)
             }
-            
+
             let translations = try! fileNode.nodes(forXPath: "body/trans-unit")
             for case let translation as XMLElement in translations {
                 if translation.attribute(forName: "id")?.stringValue.map(EXCLUDED_TRANSLATIONS.contains) == true {
                     translation.detach()
                 }
-                
+
                 if let comment = translation.attribute(forName: "id")?.stringValue.flatMap({ commentOverrides[$0] }) {
                     if let element = try? translation.nodes(forXPath: "note").first {
                         element.setStringValue(comment, resolvingEntities: true)
                     }
                 }
             }
-            
+
             let remainingTranslations = try! fileNode.nodes(forXPath: "body/trans-unit")
-            
+
             if remainingTranslations.isEmpty {
                 fileNode.detach()
             }
@@ -80,8 +80,8 @@ struct ExportTask {
 
         try! xml.xmlString.write(to: url, atomically: true, encoding: .utf8)
     }
-    
-    
+
+
     private func copyToL10NRepo(locale: String) {
         let source = URL(fileURLWithPath: "\(EXPORT_BASE_PATH)/\(locale).xcloc/Localized Contents/\(locale).xliff")
         let l10nLocale: String
@@ -94,7 +94,7 @@ struct ExportTask {
         _ = try! FileManager.default.replaceItemAt(destination, withItemAt: source)
     }
 
-    
+
     func run() {
         exportLocales()
         let commentOverrideURL = URL(fileURLWithPath: xcodeProjPath).deletingLastPathComponent().appendingPathComponent("l10n_comments.txt")
@@ -105,7 +105,7 @@ struct ExportTask {
                 guard let key = items.first, let value = items.last else { return }
                 result[String(key)] = String(value)
             } ?? [:]
-        
+
         locales.forEach { locale in
             group.enter()
             queue.async {
@@ -114,7 +114,7 @@ struct ExportTask {
                 group.leave()
             }
         }
-        
+
         group.wait()
         print(xcodeProjPath, l10nRepoPath, locales)
     }

--- a/Sources/LocalizationTools/tasks/ImportTask.swift
+++ b/Sources/LocalizationTools/tasks/ImportTask.swift
@@ -36,14 +36,16 @@ struct ImportTask {
         "nn-NO": "nn",
         "sv-SE": "sv",
         "tl"   : "fil",
-        "sat"  : "sat-Olck"
+        "sat"  : "sat-Olck",
     ]
 
     // We don't want to expose these to our localization team
     private let EXCLUDED_TRANSLATIONS: Set<String> = ["CFBundleName", "CFBundleDisplayName", "CFBundleShortVersionString"]
 
-    // InfoPlist.strings require these keys to have content or the application will crash
+    // Application will crash without the IDs in Info.plist
+    // App Store requires strings in WidgetKit
     private let REQUIRED_TRANSLATIONS: Set<String> = [
+        /// Client/Info.plist
         "NSCameraUsageDescription",
         "NSLocationWhenInUseUsageDescription",
         "NSMicrophoneUsageDescription",
@@ -51,6 +53,23 @@ struct ImportTask {
         "ShortcutItemTitleNewPrivateTab",
         "ShortcutItemTitleNewTab",
         "ShortcutItemTitleQRCode",
+        /// WidgetKit/en-US.lproj/WidgetIntents.strings
+		"2GqvPe",
+		"ctDNmu",
+		"eHmH1H",
+		"eqyNJg",
+		"eV8mOT",
+		"fi3W24-2GqvPe",
+		"fi3W24-eHmH1H",
+		"fi3W24-scEmjs",
+		"fi3W24-xRJbBP",
+		"PzSrmZ-2GqvPe",
+		"PzSrmZ-eHmH1H",
+		"PzSrmZ-scEmjs",
+		"PzSrmZ-xRJbBP",
+		"scEmjs",
+		"w9jdPK",
+		"xRJbBP",
     ]
 
     func createXcloc(locale: String) -> URL {

--- a/Sources/LocalizationTools/tasks/ImportTask.swift
+++ b/Sources/LocalizationTools/tasks/ImportTask.swift
@@ -52,7 +52,7 @@ struct ImportTask {
         "ShortcutItemTitleNewTab",
         "ShortcutItemTitleQRCode",
     ]
-    
+
     func createXcloc(locale: String) -> URL {
         let source = URL(fileURLWithPath: "\(l10nRepoPath)/\(locale)/firefox-ios.xliff")
         let locale = LOCALE_MAPPING[locale] ?? locale
@@ -60,16 +60,16 @@ struct ImportTask {
         let destination = temporaryDir.appendingPathComponent("\(locale).xcloc/Localized Contents/\(locale).xliff")
         let sourceContentsDestination = temporaryDir.appendingPathComponent("\(locale).xcloc/Source Contents/temp.txt")
         let manifestDestination = temporaryDir.appendingPathComponent("\(locale).xcloc/contents.json")
-    
+
         let fileExists = FileManager.default.fileExists(atPath: tmp.path)
         let destinationExists = FileManager.default.fileExists(atPath: destination.deletingLastPathComponent().path)
-        
+
         if fileExists {
             try! FileManager.default.removeItem(at: tmp)
         }
-        
+
         try! FileManager.default.copyItem(at: source, to: tmp)
-        
+
         if !destinationExists {
             try! FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
             try! FileManager.default.createDirectory(at: sourceContentsDestination, withIntermediateDirectories: true)
@@ -78,17 +78,17 @@ struct ImportTask {
         try! generateManifest(LOCALE_MAPPING[locale] ?? locale).write(to: manifestDestination, atomically: true, encoding: .utf8)
         return try! FileManager.default.replaceItemAt(destination, withItemAt: tmp)!
     }
-    
+
     func validateXml(fileUrl: URL, locale: String) {
         let xml = try! XMLDocument(contentsOf: fileUrl, options: .nodePreserveWhitespace)
         guard let root = xml.rootElement() else { return }
         let fileNodes =  try! root.nodes(forXPath: "file")
-        
+
         for case let fileNode as XMLElement in fileNodes {
             if let xcodeLocale = LOCALE_MAPPING[locale] {
                 fileNode.attribute(forName: "target-language")?.setStringValue(xcodeLocale, resolvingEntities: false)
             }
-            
+
             var translations = try! fileNode.nodes(forXPath: "body/trans-unit")
             for case let translation as XMLElement in translations {
                 if translation.attribute(forName: "id")?.stringValue.map(EXCLUDED_TRANSLATIONS.contains) == true {
@@ -108,10 +108,10 @@ struct ImportTask {
                 fileNode.detach()
             }
         }
-        
+
         try! xml.xmlString(options: .nodePrettyPrint).write(to: fileUrl, atomically: true, encoding: .utf16)
     }
-    
+
     private func importLocale(xclocPath: URL) {
         let command = "xcodebuild -importLocalizations -project \(xcodeProjPath) -localizationPath \(xclocPath.path)"
 
@@ -121,7 +121,7 @@ struct ImportTask {
         try! task.run()
         task.waitUntilExit()
     }
-    
+
     private func prepareLocale(locale: String) {
         let xliffUrl = createXcloc(locale: locale)
         validateXml(fileUrl: xliffUrl, locale: locale)


### PR DESCRIPTION
See https://github.com/mozilla-mobile/firefox-ios/pull/11691

There are two commits.
* The first only removes whitespaces from all swift files under Sources (that's guideline in iOS, as far as I understood). I was tempted to do it with the previous PR, but gave up on this one.
* The [second](https://github.com/mozilla-mobile/LocalizationTools/commit/ff739a2292309cddeaca28a9a17b801b0a1a5118) actually add those keys. Also removing the array from the Export task, since it's unused.