### PR TITLE
Refactor [Localization] Drop es-ES, add Tamazight mapping

### DIFF
--- a/Sources/LocalizationTools/tasks/ImportTask.swift
+++ b/Sources/LocalizationTools/tasks/ImportTask.swift
@@ -36,6 +36,7 @@ struct ImportTask {
         "sv-SE": "sv",
         "tl"   : "fil",
         "sat"  : "sat-Olck",
+        "zgh"  : "tzm",
     ]
 
     // We don't want to expose these to our localization team

--- a/Sources/LocalizationTools/tasks/ImportTask.swift
+++ b/Sources/LocalizationTools/tasks/ImportTask.swift
@@ -30,7 +30,6 @@ struct ImportTask {
 
     /// This dictionary holds locale mappings between `[XCodeLocaleCode: PontoonLocaleCode]`.
     private let LOCALE_MAPPING = [
-        "es-ES": "es",
         "ga-IE": "ga",
         "nb-NO": "nb",
         "nn-NO": "nn",


### PR DESCRIPTION
Both Focus and Firefox actually have an `es` locale generated in GitHub workflows from `es-ES`.